### PR TITLE
[bugfix] activateMixer() tries to use deprecated method to load assets

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,24 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 # dotenv environment variables file
 .env
 dist/
+
+#jetbrains ide config
+.idea

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/roundware/roundware-web.git"
   },
-  "version": "0.10.0-0",
+  "version": "0.10.0-1",
   "description": "Client framework for Roundware, a location-based contributory audio platform",
   "main": "dist/roundware.js",
   "files": [
@@ -36,23 +36,23 @@
     "url": "https://github.com/roundware/roundware-web/issues"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.4",
-    "@babel/core": "^7.9.0",
-    "@babel/node": "^7.8.7",
-    "@babel/preset-env": "~7.5.5",
+    "@babel/cli": "^7.10.5",
+    "@babel/core": "^7.10.5",
+    "@babel/node": "^7.10.5",
+    "@babel/preset-env": "^7.10.4",
     "babel-loader": "~8.0.6",
     "eslint": "6.1.0",
     "eslint-loader": "2.2.1",
     "eslint-plugin-compat": "3.3.0",
     "jasmine": "^3.5.0",
     "jsdoc": "^3.6.4",
-    "np": "^6.2.1",
+    "np": "^6.3.2",
     "npm-run-all": "^4.1.5",
     "pryjs": "^1.0.3",
     "rimraf": "~2.6.3",
-    "webpack": "^4.42.1",
-    "webpack-cli": "^3.3.11",
-    "webpack-dev-server": "~3.7.2"
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.12",
+    "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
     "@turf/boolean-point-in-polygon": "^6.0.1",
@@ -62,8 +62,8 @@
     "cancelandholdattime-polyfill": "1.15.1",
     "core-js": "3.2.0",
     "deep-extend": ">=0.5.1",
-    "loglevel": "^1.6.7",
-    "standardized-audio-context": "^24.1.5"
+    "loglevel": "^1.6.8",
+    "standardized-audio-context": "^24.1.22"
   },
   "np": {
     "anyBranch": true,

--- a/src/roundware.js
+++ b/src/roundware.js
@@ -181,7 +181,7 @@ export class Roundware {
 
   async activateMixer(activationParams = {}) {
     // Make sure the asset pool is loaded.
-    await this.loadAssets();
+    await this.loadAssetPool();
 
     const mixParams = {
       ...this.mixParams,

--- a/src/speaker_track.js
+++ b/src/speaker_track.js
@@ -3,7 +3,6 @@ import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import pointToLineDistance from '@turf/point-to-line-distance';
 import lineToPolygon from '@turf/line-to-polygon';
 import { cleanAudioURL } from './utils';
-import { Audio } from "standardized-audio-context";
 
 const convertLinesToPolygon = shape => lineToPolygon(shape);
 const FADE_DURATION_SECONDS = 3;


### PR DESCRIPTION
update call from (deprecated) loadAssets to (new) loadAssetPool